### PR TITLE
Fix libpatricia build error when HAVE_IPV6 is defined

### DIFF
--- a/libpatricia/patricia.c
+++ b/libpatricia/patricia.c
@@ -237,7 +237,7 @@ New_Prefix2 (int family, void *dest, int bitlen, prefix_t *prefix)
     if (family == AF_INET6) {
         default_bitlen = 128;
 	if (prefix == NULL) {
-            prefix = calloc(1, sizeof (prefix6_t));
+            prefix = calloc(1, sizeof (prefix_t));
 	    dynamic_allocated++;
 	}
 	memcpy (&prefix->add.sin6, dest, 16);


### PR DESCRIPTION
The "prefix6_t" type doesn't exist in the libpatricia code and
should probably be replaced with "prefix_t" instead.