### PR TITLE
Fix strntotime() overflow and other bugs

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -167,6 +167,6 @@ void chomp(char *line);
  *
  * @return 0 if no errors, negative values if errors occur
  */
-int strntotime(char* buf, size_t len, uint32_t *sec, uint32_t* usec);
+int strntotime(const char* buf, size_t len, uint32_t *sec, uint32_t* usec);
 
 #endif /* __UTILS_H */


### PR DESCRIPTION
Compared to previous version of strntotime(), this version:
- returns an error for inputs between 4294967296 and 9999999999, instead of
  overflowing
- returns an error for illegal characters past the 6th decimal place
- accepts any number of leading 0's
- takes a const argument
- is 2-4x faster