### PR TITLE
Fix GCC 12.2 warning in access to patricia_t members

### DIFF
--- a/libpatricia/patricia.c
+++ b/libpatricia/patricia.c
@@ -186,6 +186,7 @@ prefix_t *New_Prefix2(int family, void *dest, int bitlen, prefix_t *prefix)
 {
   int dynamic_allocated = 0;
   int default_bitlen = sizeof(struct in_addr) * 8;
+  prefix4_t *p4 = NULL;
 
 #ifdef HAVE_IPV6
   if (family == AF_INET6) {
@@ -214,11 +215,12 @@ prefix_t *New_Prefix2(int family, void *dest, int bitlen, prefix_t *prefix)
     return (NULL);
   }
 
-  prefix->bitlen = (bitlen >= 0) ? bitlen : default_bitlen;
-  prefix->family = family;
-  prefix->ref_count = 0;
+  p4 = (prefix4_t*) prefix;
+  p4->bitlen = (bitlen >= 0) ? bitlen : default_bitlen;
+  p4->family = family;
+  p4->ref_count = 0;
   if (dynamic_allocated) {
-    prefix->ref_count++;
+    p4->ref_count++;
   }
   /* fprintf(stderr, "[C %s, %d]\n", prefix_toa (prefix), prefix->ref_count);
    */


### PR DESCRIPTION
Hi folks — we're seeing a few warnings in the libpatricia code with newer GCCs:

```
/home/christian/devel/zeek/zeek/src/3rdparty/patricia.c:246:18: warning: array subscript ‘prefix_t {aka struct _prefix_t}[0]’ is partly outside array bounds of ‘unsigned char[12]’ [-Warray-bounds]
  246 |   prefix->bitlen = (bitlen >= 0) ? bitlen : default_bitlen;
      |   ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/christian/devel/zeek/zeek/src/3rdparty/patricia.c:228:18: note: object of size 12 allocated by ‘calloc’
  228 |         prefix = calloc(1, sizeof(prefix4_t));
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/christian/devel/zeek/zeek/src/3rdparty/patricia.c:247:18: warning: array subscript ‘prefix_t {aka struct _prefix_t}[0]’ is partly outside array bounds of ‘unsigned char[12]’ [-Warray-bounds]
  247 |   prefix->family = family;
      |   ~~~~~~~~~~~~~~~^~~~~~~~
/home/christian/devel/zeek/zeek/src/3rdparty/patricia.c:228:18: note: object of size 12 allocated by ‘calloc’
  228 |         prefix = calloc(1, sizeof(prefix4_t));
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/christian/devel/zeek/zeek/src/3rdparty/patricia.c:248:21: warning: array subscript ‘prefix_t {aka struct _prefix_t}[0]’ is partly outside array bounds of ‘unsigned char[12]’ [-Warray-bounds]
  248 |   prefix->ref_count = 0;
      |   ~~~~~~~~~~~~~~~~~~^~~
/home/christian/devel/zeek/zeek/src/3rdparty/patricia.c:228:18: note: object of size 12 allocated by ‘calloc’
  228 |         prefix = calloc(1, sizeof(prefix4_t));
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/christian/devel/zeek/zeek/src/3rdparty/patricia.c:250:22: warning: array subscript ‘prefix_t {aka struct _prefix_t}[0]’ is partly outside array bounds of ‘unsigned char[12]’ [-Warray-bounds]
  250 |     prefix->ref_count++;
      |     ~~~~~~~~~~~~~~~~~^~
/home/christian/devel/zeek/zeek/src/3rdparty/patricia.c:228:18: note: object of size 12 allocated by ‘calloc’
  228 |         prefix = calloc(1, sizeof(prefix4_t));
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
The above is based on Zeek's version of libpatricia, but the code in question is identical. I wasn't able to test the included tweak directly with your repo but the equivalent fix on the Zeek side resolves them.